### PR TITLE
Storage namespace

### DIFF
--- a/env/run_experiment.py
+++ b/env/run_experiment.py
@@ -115,9 +115,9 @@ def launch_storage_mon():
                   " Did you run the deployment script?")
         sys.exit(util.EXIT_FAILURE)
     cmd = "kubectl get pods -lapp=storage-upstream "
-    cmd += " -o jsonpath={.items[0].metadata.name}"
+    cmd += " -o jsonpath={.items[0].metadata.name} -n=storage"
     storage_pod_name = util.get_output_from_proc(cmd).decode("utf-8")
-    cmd = f"kubectl port-forward {storage_pod_name} 8090:8080"
+    cmd = f"kubectl -n=storage port-forward {storage_pod_name} 8090:8080"
     storage_proc = util.start_process(cmd, preexec_fn=os.setsid)
     # Let settle things in a bit
     time.sleep(2)

--- a/env/yaml_crds/productpage-cluster.yaml
+++ b/env/yaml_crds/productpage-cluster.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: productpage-storage-upstream-cluster
-  namespace: storage
 spec:
   configPatches:
     - applyTo: CLUSTER

--- a/env/yaml_crds/productpage-cluster.yaml
+++ b/env/yaml_crds/productpage-cluster.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: productpage-storage-upstream-cluster
-  namespace: default
+  namespace: storage
 spec:
   configPatches:
     - applyTo: CLUSTER

--- a/env/yaml_crds/storage-upstream.yaml
+++ b/env/yaml_crds/storage-upstream.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: storage-upstream
+  namespace: storage
   labels:
     name: storage-upstream
 spec:
@@ -10,9 +11,6 @@ spec:
       app: storage-upstream
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/userVolume: '[{"name":"wasmfilters-dir","configMap": {"name": "example-filter"}}]'
-        sidecar.istio.io/userVolumeMount: '[{"mountPath":"/var/local/lib/wasm-filters","name":"wasmfilters-dir"}]'
       labels:
         app: storage-upstream
     spec:
@@ -26,6 +24,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: storage-upstream
+  namespace: storage
 spec:
   type: ClusterIP
   selector:
@@ -34,5 +33,19 @@ spec:
   - name: storage-upstream
     port: 8080
     targetPort: 8080
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: storage-upstream
+spec:
+  type: ExternalName
+  externalName: storage-upstream.storage.svc.cluster.local
+  ports:
+  - name: storage-upstream
+    port: 8080
+    targetPort: 8080
+
+
 
 # kubectl port-forward (kubectl get pods  -lapp=storage-upstream -o jsonpath={.items[0].metadata.name}) 8080

--- a/env/yaml_crds/storage-upstream.yaml
+++ b/env/yaml_crds/storage-upstream.yaml
@@ -25,26 +25,26 @@ kind: Service
 metadata:
   name: storage-upstream
   namespace: storage
+  labels:
+    app: storage-upstream
+    service: storage-upstream
 spec:
-  type: ClusterIP
+  ports:
+  - port: 8080
+    name: http
   selector:
     app: storage-upstream
-  ports:
-  - name: storage-upstream
-    port: 8080
-    targetPort: 8080
 ---
 kind: Service
 apiVersion: v1
 metadata:
   name: storage-upstream
+  namespace: default
 spec:
   type: ExternalName
   externalName: storage-upstream.storage.svc.cluster.local
   ports:
-  - name: storage-upstream
-    port: 8080
-    targetPort: 8080
+  - port: 8080
 
 
 

--- a/filter.cc.handlebars
+++ b/filter.cc.handlebars
@@ -263,7 +263,7 @@ void BidiContext::onResponseHeadersInbound() {
       LOG_WARN(std::string(body->view()));
     };
 
-    auto result = root()->httpCall("storage-upstream.storage",
+    auto result = root()->httpCall("storage-upstream",
                                    { {":method", "GET"},
                                     {":path", "/store"},
                                     {":authority", "storage-upstream"},

--- a/filter.cc.handlebars
+++ b/filter.cc.handlebars
@@ -263,7 +263,7 @@ void BidiContext::onResponseHeadersInbound() {
       LOG_WARN(std::string(body->view()));
     };
 
-    auto result = root()->httpCall("storage-upstream",
+    auto result = root()->httpCall("storage-upstream.storage",
                                    { {":method", "GET"},
                                     {":path", "/store"},
                                     {":authority", "storage-upstream"},


### PR DESCRIPTION
This pull request moves the storage app into a separate namespace so it is not affected by istio or any commands in the default namespace. With this change, the `kube_env` script should work out of the box because we do not have to add extra rules for storage.