### PR TITLE
Fix bazel build.

### DIFF
--- a/cpp_filter/WORKSPACE
+++ b/cpp_filter/WORKSPACE
@@ -49,20 +49,18 @@ new_git_repository(
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
+# rules_proto defines abstract rules for building Protocol Buffers.
+git_repository(
     name = "rules_proto",
-    sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
-    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-    ],
+    commit = "cfdc2fa31879c0aebe31ce7702b1a9c8a4be02d2",
+    remote = "https://github.com/bazelbuild/rules_proto"
 )
+
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 rules_proto_dependencies()
 rules_proto_toolchains()
+
 
 # Built against ABI 0_2_0
 http_archive(


### PR DESCRIPTION
Protobuf was broken for recent versions of bazel (it depended on protoinfo). This should fix the issue.