### PR TITLE
Updating rust compilation to be in line with new nodes with properties

### DIFF
--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -3,7 +3,7 @@ mod graph_utils;
 use rpc_lib::rpc::Rpc;
 use std::collections::HashMap;
 use std::fs;
-use petgraph::algo::isomorphic_subgraph_mapping;
+use petgraph::algo::isomorphic_subgraph_matching;
 use petgraph::graph::NodeIndex;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
@@ -66,7 +66,23 @@ impl Filter {
     #[no_mangle]
     pub fn execute(&mut self, x: &Rpc) -> Option<Rpc> {
         // 0. Who am I?
-        let my_node = self.filter_state.get("WORKLOAD_NAME").unwrap().string_data.clone().unwrap();
+        let my_node_wrapped = self
+            .filter_state
+            .get("node.metadata.WORKLOAD_NAME");
+        if my_node_wrapped.is_none() {
+            print!("WARNING: filter was initialized without envoy properties and thus cannot function");
+            return Some(Rpc {
+                       data: x.data,
+                       uid: x.uid,
+                       path: x.path.clone(),
+                   });
+        }
+        let my_node = my_node_wrapped
+            .unwrap()
+            .string_data
+            .clone()
+            .unwrap();
+
 
         // 1. Do I need to put any udf variables/objects in?
         {{#each rust_udfs}}
@@ -86,17 +102,37 @@ impl Filter {
             // we need to create the graph given by the query
             let vertices = vec![ {{#each vertices}}String::from("{{this}}"), {{/each}}  ];
             let edges = vec![ {{#each edges}} ( {{#each this}}String::from("{{this}}"), {{/each}} ), {{/each}} ];
-            let mut ids_to_properties: HashMap<String, Vec<String>> = HashMap::new();
+            // ids_to_properties is a HashMap taking <(NodeName, Properties), Desired Value>, so if the query says
+            // a.service_name == productpagev1"
+            // in ids_to_properties we have
+            // ids_to_properties("a", { node.metadata.WORKLOAD_NAME = "productpage-v1" } )
+            let mut ids_to_properties: HashMap<String, HashMap<String, String>> = HashMap::new();
             {{#each nodes_to_attributes}}
-            ids_to_properties.insert(String::from("{{this.id}}"), vec![ {{#each this.parts}} String::from("{{this}}"), {{/each}} ]);
+            let properties = vec! [ {{#each this.parts}} String::from("{{this}}"), {{/each}} ].join(".");
+            {{/each}}
+
+            {{#each vertices}}
+            let mut {{this}}_hashmap = HashMap::new();
+            {{this}}_hashmap.insert(properties.clone(), "{{this}}".to_string());
+            ids_to_properties.insert("{{this}}".to_string(), {{this}}_hashmap);
             {{/each}}
 
 
-            let target = graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
+            let target_graph = graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
             let trace_graph = graph_utils::generate_trace_graph_from_headers(x.path.clone());
-            let wrapped_mapping = isomorphic_subgraph_mapping(&trace_graph, &target);
-            if !wrapped_mapping.is_none() {
-                let mapping = wrapped_mapping.unwrap();
+            let mapping = isomorphic_subgraph_matching(
+                &target_graph,
+                &trace_graph,
+                |x, y| {
+                    for property in y.1.keys() {
+                        if property != &"node.metadata.WORKLOAD_NAME".to_string() && &(x.1[property]) != &(y.1[property]) { return false; }
+                    }
+                return true;
+                },
+                |x, y| x == y,
+            );
+            if !mapping.is_none() {
+                let m = mapping.unwrap();
                 // In the non-simulator version, we will send the result to storage.  Given this is
                 // a simulation, we will write it to a file.
                 {{#each rust_blocks}}{{{this}}}{{/each}}
@@ -111,7 +147,6 @@ impl Filter {
 
             }
         }
-
         // 4.  Allow udfs to execute
         {{#each rust_udfs}}
         let {{this.id}}_state_ptr = self.filter_state.get_mut("{{this.id}}").unwrap();

--- a/rust_filter/src/graph_utils.rs
+++ b/rust_filter/src/graph_utils.rs
@@ -1,9 +1,8 @@
 /* This file contains functions relating to creating and comparing trace and target (user-given) graphs */
 
+use petgraph::algo::{dijkstra, toposort};
 use petgraph::graph::{Graph, NodeIndex};
-use petgraph::algo::{toposort, dijkstra};
 use std::collections::HashMap;
-
 
 /* This function creates a petgraph graph representing the query given by the user.
  * For example, if the cql query were MATCH n -> m, e WHERE ... the input to this function
@@ -17,18 +16,20 @@ use std::collections::HashMap;
  * @graph: the constructed graph reprsenting the inputs
  */
 
-pub fn generate_target_graph(vertices: Vec<String>,
-                            edges: Vec<(String, String)>,
-                            _ids_to_properties: HashMap<String, Vec<String>>)
-                           -> Graph<String, String> {
+pub fn generate_target_graph(
+    vertices: Vec<String>,
+    edges: Vec<(String, String)>,
+    ids_to_properties: HashMap<String, HashMap<String, String>>,
+) -> Graph<(String, HashMap<String, String>), String> {
     let mut graph = Graph::new();
 
-    // In order to make edges, we have to know the handles of the nodes, and you 
+    // In order to make edges, we have to know the handles of the nodes, and you
     // get the handles of the nodes by adding them to the graph
 
     let mut nodes_to_node_handles: HashMap<String, NodeIndex> = HashMap::new();
     for node in vertices {
-        nodes_to_node_handles.insert(node.clone(), graph.add_node(node.clone()));
+        assert!(ids_to_properties.contains_key(&node), "{0} is a node that wasn't in ids_to_properties\n", node);
+        nodes_to_node_handles.insert(node.clone(), graph.add_node((node.clone(), ids_to_properties[&node].clone())));
     }
 
     // Make edges with handles instead of the vertex names
@@ -44,9 +45,8 @@ pub fn generate_target_graph(vertices: Vec<String>,
     graph
 }
 
-
 /*  This function creates a petgraph graph representing a single trace.
- *  The trace is represented in paths_header as a string where the first node is 
+ *  The trace is represented in paths_header as a string where the first node is
  *  the root.  Thus "0 1 2" is a graph that looks like 0 -> 1 -> 2 with 0 as root.
  *
  *  Arguments:
@@ -55,7 +55,9 @@ pub fn generate_target_graph(vertices: Vec<String>,
  *  Return Value:
  *  @graph:  A petgraph graph representation of the same trace
  */
-pub fn generate_trace_graph_from_headers(paths_header: String) -> Graph<String, String> {
+pub fn generate_trace_graph_from_headers(
+    paths_header: String,
+) -> Graph<(String, HashMap<String, String>), String> {
     let mut graph = Graph::new();
     let mut nodes_iterator = paths_header.split_whitespace();
     let mut node_str_to_node_handle = HashMap::new();
@@ -64,17 +66,29 @@ pub fn generate_trace_graph_from_headers(paths_header: String) -> Graph<String, 
         return graph; // clearly we don't have anything, so return an empty graph
     }
     let first_node_str = first_node.unwrap();
-    node_str_to_node_handle.insert(first_node_str.to_string(), graph.add_node(first_node_str.to_string()));
+    let mut first_node_hashmap = HashMap::new();
+    first_node_hashmap.insert(
+        "node.metadata.WORKLOAD_NAME".to_string(),
+        first_node_str.to_string(),
+    );
+    node_str_to_node_handle.insert(
+        first_node_str.to_string(),
+        graph.add_node((first_node_str.to_string(), first_node_hashmap)),
+    );
     let mut prev_node_handle = node_str_to_node_handle[first_node_str];
     for node_str in nodes_iterator {
         // 1. Is this node already in the graph?  If so, ignore it and move "up" the tree
-        if !node_str_to_node_handle.contains_key(node_str) {
-            let new_node_handle = graph.add_node(node_str.to_string());
+        if !node_str_to_node_handle.contains_key(&node_str.to_string()) {
+            let mut new_node_hashmap = HashMap::new();
+            new_node_hashmap.insert(
+                "node.metadata.WORKLOAD_NAME".to_string(),
+                node_str.to_string(),
+            );
+            let new_node_handle = graph.add_node((node_str.to_string(), new_node_hashmap));
             node_str_to_node_handle.insert(node_str.to_string(), new_node_handle);
             graph.add_edge(prev_node_handle, new_node_handle, "".to_string());
             prev_node_handle = new_node_handle;
-        }
-        else {
+        } else {
             prev_node_handle = node_str_to_node_handle[node_str];
         }
     }
@@ -90,10 +104,14 @@ pub fn get_node_with_id(graph: &Graph<String, String>, node_name: String) -> Opt
     None
 }
 
-pub fn get_tree_height(graph: &Graph<String, String>, root: Option<NodeIndex>) -> u32 {
+pub fn get_tree_height(
+    graph: &Graph<(String, HashMap<String, String>), String>,
+    root: Option<NodeIndex>,
+) -> u32 {
     let starting_point;
-    if !root.is_none() { starting_point = root.unwrap() }
-    else {
+    if !root.is_none() {
+        starting_point = root.unwrap()
+    } else {
         // The root of the tree by definition has no incoming edges
         let sorted = toposort(graph, None).unwrap();
         starting_point = sorted[0];
@@ -108,26 +126,57 @@ pub fn get_tree_height(graph: &Graph<String, String>, root: Option<NodeIndex>) -
     return max;
 }
 
+pub fn get_out_degree(
+    graph: &Graph<(String, HashMap<String, String>), String>,
+    root: Option<NodeIndex>,
+) -> u32 {
+    let starting_point;
+    if !root.is_none() {
+        starting_point = root.unwrap()
+    } else {
+        // The root of the tree by definition has no incoming edges
+        let sorted = toposort(graph, None).unwrap();
+        starting_point = sorted[0];
+    }
+    return graph.neighbors(starting_point).count() as u32;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn make_small_trace_graph() -> Graph<String, String> {
+    fn make_small_trace_graph() -> Graph<(String, HashMap<String, String>), String> {
         let graph_string = String::from("0 1 2");
         let graph = generate_trace_graph_from_headers(graph_string);
         graph
     }
 
-
-    fn make_small_target_graph() -> Graph<String, String> {
+    fn make_small_target_graph() -> Graph<(String, HashMap<String, String>), String> {
         let a = String::from("a");
         let b = String::from("b");
         let c = String::from("c");
-        let vertices = vec![ a.clone(), b.clone(), c.clone()];
+        let vertices = vec![a.clone(), b.clone(), c.clone()];
         let edges = vec![(a.clone(), b.clone()), (b.clone(), c.clone())];
         let mut ids_to_properties = HashMap::new();
-        for vertex in vertices.clone() {
-            ids_to_properties.insert(vertex.clone(), Vec::new());
+
+        let mut a_hashmap = HashMap::new();
+        a_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "a".to_string());
+        ids_to_properties.insert("a".to_string(), a_hashmap);
+
+        let mut b_hashmap = HashMap::new();
+        b_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "b".to_string());
+        ids_to_properties.insert("b".to_string(), b_hashmap);
+
+        let mut c_hashmap = HashMap::new();
+        c_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "c".to_string());
+        ids_to_properties.insert("c".to_string(), c_hashmap);
+
+        assert!(ids_to_properties.keys().len()==3);
+        assert!(ids_to_properties.contains_key(&"a".to_string()));
+        assert!(ids_to_properties.contains_key(&"b".to_string()));
+        assert!(ids_to_properties.contains_key(&"c".to_string()));
+        for vertex in &vertices {
+            assert!(ids_to_properties.contains_key(vertex));
         }
         let graph = generate_target_graph(vertices, edges, ids_to_properties);
         graph
@@ -147,31 +196,35 @@ mod tests {
         assert_eq!(graph.edge_count(), 2);
     }
 
-
     #[test]
     fn test_correctly_parse_branching_graphs() {
         let graph = generate_trace_graph_from_headers("0 1 3 1 2".to_string());
-        assert!(graph.node_count()==4);
+        assert!(graph.node_count() == 4);
         for node in graph.node_indices() {
-            if graph.node_weight(node).unwrap() == "0" {
+            if graph.node_weight(node).unwrap().1["node.metadata.WORKLOAD_NAME"] == "0" {
                 assert!(graph.neighbors(node).count() == 1);
             }
-            if graph.node_weight(node).unwrap() == "1" {
+            if graph.node_weight(node).unwrap().1["node.metadata.WORKLOAD_NAME"] == "1" {
                 assert!(graph.neighbors(node).count() == 2);
             }
         }
-
     }
 
     #[test]
     fn test_generate_trace_graph_from_headers_on_empty_string() {
         let graph = generate_trace_graph_from_headers(String::new());
-        assert!(graph.node_count()==0);
+        assert!(graph.node_count() == 0);
     }
+
     #[test]
     fn test_get_tree_height() {
         let graph = generate_trace_graph_from_headers("0 1 3 1 2".to_string());
-        assert!(get_tree_height(&graph, None)==2);
+        assert!(get_tree_height(&graph, None) == 2);
     }
 
+    #[test]
+    fn test_get_out_degree() {
+        let straight_graph = generate_trace_graph_from_headers("0 1 2 3 4 5 6".to_string());
+        assert!(get_out_degree(&straight_graph, None) == 1);
+    }
 }


### PR DESCRIPTION
This allows the compiler to create filters that correctly deal with nodes of the form String, HashMap, which is used to represent nodeName, nodeProperties.