### PR TITLE
Changed issue where with built in identifiers like height, the filter…

### DIFF
--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -163,7 +163,6 @@ impl Filter {
 
                 {{#with result}}
                 {{#if this.Return}}{{#with this.Return}}
-                fs::write("result.txt", {{this.id}}).expect("Unable to write file");
                 {{/with}}{{/if}}
                 {{/with}}
 

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -384,7 +384,6 @@ std::string {cpp_var_id} = node_ptr->properties.at({parts});",
                         );
                     self.cpp_blocks.push(cpp_block);
 
-
                     let rust_index_code = format!("let node_index = graph_utils::get_node_with_id(&target_graph, \"{node_id}\".to_string());\n                if node_index.is_none() {{\n                    print!(\"WARNING: could not find node with id\");\n                }}\n",
                             node_id = id.id_name);
                     let rust_get_tree_height_code = format!(

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -383,10 +383,12 @@ std::string {cpp_var_id} = node_ptr->properties.at({parts});",
                             node_id = id.id_name,
                         );
                     self.cpp_blocks.push(cpp_block);
+
+
                     let rust_index_code = format!("let node_index = graph_utils::get_node_with_id(&target_graph, \"{node_id}\".to_string());\n                if node_index.is_none() {{\n                    print!(\"WARNING: could not find node with id\");\n                }}\n",
                             node_id = id.id_name);
                     let rust_get_tree_height_code = format!(
-                            "               else {{\n                    let trace_index = NodeIndex::new(mapping[node_index.unwrap().index()]);\n                    let {cpp_var_id} = graph_utils::get_tree_height(&trace_graph, Some(trace_index))+1; // we add one for ourselves - the node we are on is not added to the path until after the filter is run\n",
+                            "               else {{\n                    let trace_index = NodeIndex::new(m[node_index.unwrap().index()]);\n                    let {cpp_var_id} = graph_utils::get_tree_height(&trace_graph, Some(trace_index))+1; // we add one for ourselves - the node we are on is not added to the path until after the filter is run\n",
                             cpp_var_id = cpp_var_id,
                         );
                     let rust_error_check = format!("                    let ret = fs::write(\"result.txt\", {cpp_var_id}.to_string());\n                    match ret {{\n                        Ok(result) => result,\n                        Err(_e) => print!(\"WARNING: could not write result to file\"),\n                    }}; \n                }}",
@@ -417,7 +419,7 @@ std::string {cpp_var_id} = node_ptr->properties.at({parts});",
                     let rust_index_code = format!("let node_index = graph_utils::get_node_with_id(&target_graph, \"{node_id}\".to_string());\n                if node_index.is_none() {{\n                    print!(\"WARNING: could not find node with id\");\n                }}\n",
                             node_id = id.id_name);
                     let rust_get_breadth_code = format!(
-                            "               else {{\n                    let trace_index = NodeIndex::new(mapping[node_index.unwrap().index()]);\n                    let {cpp_var_id} = graph_utils::get_out_degree(&trace_graph, Some(trace_index)); // we add one for ourselves - the node we are on is not added to the path until after the filter is run\n",
+                            "               else {{\n                    let trace_index = NodeIndex::new(m[node_index.unwrap().index()]);\n                    let {cpp_var_id} = graph_utils::get_out_degree(&trace_graph, Some(trace_index)); // we add one for ourselves - the node we are on is not added to the path until after the filter is run\n",
                             cpp_var_id = cpp_var_id,
                         );
                     let rust_error_check = format!("                    let ret = fs::write(\"result.txt\", {cpp_var_id}.to_string());\n                    match ret {{\n                        Ok(result) => result,\n                        Err(_e) => print!(\"WARNING: could not write result to file\"),\n                    }}; \n                }}",


### PR DESCRIPTION
… would try to write the return statement twice

This should make the test "height.cql" pass in the tracing_env repo - I will update that once this is in.