### PR TITLE
changed how files are written

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -129,20 +129,9 @@ fn main() {
     let c_mode = matches.value_of("compilation_mode").unwrap();
     let mut output_name = PathBuf::from(matches.value_of("output").unwrap());
     if c_mode == "sim" {
-        // Because we are making a library, not just one file, we need to copy over an example library.  Then,
-        // we have to write to three files:  Cargo.toml to edit the filter name, lib.rs to edit the filter name,
-        // and <output_name>.rs for the actual filter implementation
-        let rust_dir = bin_dir.join("rust_filter");
-        // The filter itself
-        let mut filter_file_name = rust_dir.join(output_name);
-        filter_file_name.set_extension("rs");
         let filter_name_handlebars = bin_dir.join("filter.rs.handlebars");
-        print!("writing filter to {0}", filter_file_name.to_str().unwrap());
-        generate_code_from_codegen_with_handlebars(
-            &code_gen,
-            filter_name_handlebars,
-            filter_file_name,
-        );
+        print!("writing filter to {0}", output_name.to_str().unwrap());
+        generate_code_from_codegen_with_handlebars(&code_gen, filter_name_handlebars, output_name);
     } else {
         let filter_handlebars_cc = bin_dir.join("filter.cc.handlebars");
         output_name.set_extension("cc");


### PR DESCRIPTION
It used to be that we automatically put the output for the simulator to the rust_filter folder.  Given the tests, I think it is better to give more freedom for where to write the output.  This means we'll have to do things like -o ./rust_filter/filter.rs when we run the filter, but I think it makes more sense.